### PR TITLE
feat: add __repr__ and __str__ methods to API exceptions

### DIFF
--- a/src/chatapult/exceptions.py
+++ b/src/chatapult/exceptions.py
@@ -12,7 +12,11 @@ import httpx
 class ChatapultError(Exception):
     """Base exception for all Chatapult errors."""
 
-    pass
+    def __str__(self) -> str:
+        return super().__str__()
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({super().__str__()!r})"
 
 
 class ConfigurationError(ChatapultError):
@@ -41,3 +45,10 @@ class APIError(ChatapultError):
         super().__init__(message)
         self.response = response
         self.status_code = response.status_code if response is not None else None
+
+    def __str__(self) -> str:
+        status = f"[{self.status_code}] " if self.status_code else ""
+        return f"{status}{super().__str__()}"
+
+    def __repr__(self) -> str:
+        return f"APIError(message={super().__str__()!r}, status_code={self.status_code!r})"

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,22 @@
+from chatapult.exceptions import APIError, NetworkError, ConfigurationError
+import httpx
+
+def test_apierror_str_repr():
+    response = httpx.Response(status_code=404, content=b"Not Found")
+    err = APIError("Resource missing", response=response)
+    assert str(err) == "[404] Resource missing"
+    assert repr(err) == "APIError(message='Resource missing', status_code=404)"
+
+def test_apierror_no_response():
+    err = APIError("Some error")
+    assert str(err) == "Some error"
+    assert repr(err) == "APIError(message='Some error', status_code=None)"
+
+def test_base_errors_str_repr():
+    err = NetworkError("Connection lost")
+    assert str(err) == "Connection lost"
+    assert repr(err) == "NetworkError('Connection lost')"
+    
+    err2 = ConfigurationError("Invalid key")
+    assert str(err2) == "Invalid key"
+    assert repr(err2) == "ConfigurationError('Invalid key')"


### PR DESCRIPTION
This PR implements standardized `__str__` and `__repr__` methods for the custom exception classes to improve debugging and logging.

### Changes:
- Added `__str__` and `__repr__` to `ChatapultError` (base class).
- Overrode `__str__` and `__repr__` in `APIError` to include HTTP status codes.
- Added a new test file `tests/test_exceptions.py` to verify the output format.

Fixes #13