### PR TITLE
Feat/validate webhook url

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,22 @@ except APIError as e:
 
 ![Sync Message](https://raw.githubusercontent.com/DLambros91/chatapult/refs/heads/main/images/example_sync_message.png)
 
+### Mentioning Users
+
+Chatapult provides helper functions for Google Chat user mentions.
+```python
+from chatapult.formatters import mention_all, mention_user
+
+# Mention everyone in the space
+text = f"{mention_all()} Heads up, deployment is starting!"
+
+# Mention a specific user by ID
+text = f"Please review this PR from {mention_user('12345')}."
+
+with ChatClient(webhook_url) as client:
+    client.send_message(text)
+```
+
 ### Asynchronous Usage
 
 Ideal for web servers, async task queues, or applications where you cannot block the main thread.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,11 @@ except APIError as e:
 
 Chatapult provides helper functions for Google Chat user mentions.
 ```python
+import os
+from chatapult import ChatClient
 from chatapult.formatters import mention_all, mention_user
+
+webhook_url = os.environ.get("GOOGLE_CHAT_WEBHOOK_URL")
 
 # Mention everyone in the space
 text = f"{mention_all()} Heads up, deployment is starting!"

--- a/src/chatapult/async_client.py
+++ b/src/chatapult/async_client.py
@@ -21,13 +21,15 @@ class AsyncChatClient:
             timeout (float): Connection timeout in seconds. Defaults to 10.0.
 
         Raises:
-                ValueError: If the webhook_url is empty or does not start with
-                    https://chat.googleapis.com/v1/spaces/
+            ValueError: If the webhook_url is empty or does not start with
+                https://chat.googleapis.com/v1/spaces/
         """
-        if not webhook_url or not webhook_url.startswith("https://chat.googleapis.com/v1/spaces/"):
+        _WEBHOOK_PREFIX = "https://chat.googleapis.com/v1/spaces/"
+
+        if not webhook_url or not webhook_url.startswith(_WEBHOOK_PREFIX):
             raise ValueError(
                 "A valid Google Chat webhook URL is required. "
-                "It must start with: https://chat.googleapis.com/v1/spaces/"
+                f"It must start with: {_WEBHOOK_PREFIX}"
             )
 
         self.webhook_url = webhook_url

--- a/src/chatapult/async_client.py
+++ b/src/chatapult/async_client.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, Optional, List
 
 import httpx
 
-from .exceptions import APIError, ConfigurationError, NetworkError
+from .exceptions import APIError, NetworkError
 from .models import CardWithId
 
 
@@ -21,10 +21,14 @@ class AsyncChatClient:
             timeout (float): Connection timeout in seconds. Defaults to 10.0.
 
         Raises:
-            ConfigurationError: If the webhook_url is empty.
+                ValueError: If the webhook_url is empty or does not start with
+                    https://chat.googleapis.com/v1/spaces/
         """
-        if not webhook_url:
-            raise ConfigurationError("A valid webhook_url must be provided.")
+        if not webhook_url or not webhook_url.startswith("https://chat.googleapis.com/v1/spaces/"):
+            raise ValueError(
+                "A valid Google Chat webhook URL is required. "
+                "It must start with: https://chat.googleapis.com/v1/spaces/"
+            )
 
         self.webhook_url = webhook_url
         self._client = httpx.AsyncClient(timeout=timeout)

--- a/src/chatapult/client.py
+++ b/src/chatapult/client.py
@@ -21,13 +21,15 @@ class ChatClient:
             timeout (float): Connection timeout in seconds. Defaults to 10.0.
 
         Raises:
-                ValueError: If the webhook_url is empty or does not start with
-                    https://chat.googleapis.com/v1/spaces/
+            ValueError: If the webhook_url is empty or does not start with
+                https://chat.googleapis.com/v1/spaces/
         """
-        if not webhook_url or not webhook_url.startswith("https://chat.googleapis.com/v1/spaces/"):
+        _WEBHOOK_PREFIX = "https://chat.googleapis.com/v1/spaces/"
+
+        if not webhook_url or not webhook_url.startswith(_WEBHOOK_PREFIX):
             raise ValueError(
                 "A valid Google Chat webhook URL is required. "
-                "It must start with: https://chat.googleapis.com/v1/spaces/"
+                f"It must start with: {_WEBHOOK_PREFIX}"
             )
 
         self.webhook_url = webhook_url

--- a/src/chatapult/client.py
+++ b/src/chatapult/client.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, Optional, List
 import httpx
 
 # Import our new custom exceptions
-from .exceptions import APIError, ConfigurationError, NetworkError
+from .exceptions import APIError, NetworkError
 from .models import CardWithId
 
 
@@ -21,10 +21,14 @@ class ChatClient:
             timeout (float): Connection timeout in seconds. Defaults to 10.0.
 
         Raises:
-            ConfigurationError: If the webhook_url is empty or invalid.
+                ValueError: If the webhook_url is empty or does not start with
+                    https://chat.googleapis.com/v1/spaces/
         """
-        if not webhook_url:
-            raise ConfigurationError("A valid webhook_url must be provided.")
+        if not webhook_url or not webhook_url.startswith("https://chat.googleapis.com/v1/spaces/"):
+            raise ValueError(
+                "A valid Google Chat webhook URL is required. "
+                "It must start with: https://chat.googleapis.com/v1/spaces/"
+            )
 
         self.webhook_url = webhook_url
         self._client = httpx.Client(timeout=timeout)

--- a/src/chatapult/formatters.py
+++ b/src/chatapult/formatters.py
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Helper functions for Google Chat mention formatting.
+"""
+
+
+def mention_all() -> str:
+    """Return the mention string to notify all users in a space."""
+    return "<users/all>"
+
+
+def mention_user(user_id: str) -> str:
+    """Return the mention string for a specific user by their ID."""
+    return f"<users/{user_id}>"

--- a/src/chatapult/formatters.py
+++ b/src/chatapult/formatters.py
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""
-Helper functions for Google Chat mention formatting.
-"""
+"""Helper functions for Google Chat mention formatting."""
 
 
 def mention_all() -> str:

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -5,7 +5,7 @@ from pytest_httpx import HTTPXMock
 
 from chatapult.client import ChatClient
 from chatapult.async_client import AsyncChatClient
-from chatapult.exceptions import APIError, ConfigurationError, NetworkError
+from chatapult.exceptions import APIError, NetworkError
 from chatapult.models import CardWithId, Card
 
 # Dummy webhook URL for testing
@@ -20,7 +20,7 @@ WEBHOOK_URL = (
 
 
 def test_sync_client_init_empty_url() -> None:
-    """Ensure ChatClient raises ConfigurationError if webhook is empty."""
+    """Ensure ChatClient raises ValueError if webhook is empty."""
     with pytest.raises(ValueError):
         ChatClient(webhook_url="")
 
@@ -106,24 +106,32 @@ def test_sync_empty_message() -> None:
         ):
             client.send_message()
 
-def test_chat_client_invalid_url_raises_value_error():
+
+def test_chat_client_invalid_url_raises_value_error() -> None:
+    """Test that ChatClient raises ValueError for an invalid webhook URL."""
     with pytest.raises(ValueError):
         ChatClient("https://invalid-url.com")
 
-def test_async_chat_client_invalid_url_raises_value_error():
+
+def test_async_chat_client_invalid_url_raises_value_error() -> None:
+    """Test that AsyncChatClient raises ValueError for an invalid webhook URL."""
     with pytest.raises(ValueError):
         AsyncChatClient("https://invalid-url.com")
 
-def test_chat_client_empty_url_raises_value_error():
+
+def test_chat_client_empty_url_raises_value_error() -> None:
+    """Test that ChatClient raises ValueError for an empty webhook URL."""
     with pytest.raises(ValueError):
         ChatClient("")
+
+
 # ---------------------------------------------------------------------------
 # Asynchronous Client Tests
 # ---------------------------------------------------------------------------
 
 
 def test_async_client_init_empty_url() -> None:
-    """Ensure AsyncChatClient raises ConfigurationError if webhook is empty."""
+    """Ensure AsyncChatClient raises ValueError if webhook is empty."""
     with pytest.raises(ValueError):
         AsyncChatClient(webhook_url="")
 
@@ -205,4 +213,3 @@ async def test_async_empty_message() -> None:
             ValueError, match="You must provide either 'text' or 'cards'"
         ):
             await client.send_message()
-

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -21,7 +21,7 @@ WEBHOOK_URL = (
 
 def test_sync_client_init_empty_url() -> None:
     """Ensure ChatClient raises ConfigurationError if webhook is empty."""
-    with pytest.raises(ConfigurationError):
+    with pytest.raises(ValueError):
         ChatClient(webhook_url="")
 
 
@@ -106,7 +106,17 @@ def test_sync_empty_message() -> None:
         ):
             client.send_message()
 
+def test_chat_client_invalid_url_raises_value_error():
+    with pytest.raises(ValueError):
+        ChatClient("https://invalid-url.com")
 
+def test_async_chat_client_invalid_url_raises_value_error():
+    with pytest.raises(ValueError):
+        AsyncChatClient("https://invalid-url.com")
+
+def test_chat_client_empty_url_raises_value_error():
+    with pytest.raises(ValueError):
+        ChatClient("")
 # ---------------------------------------------------------------------------
 # Asynchronous Client Tests
 # ---------------------------------------------------------------------------
@@ -114,7 +124,7 @@ def test_sync_empty_message() -> None:
 
 def test_async_client_init_empty_url() -> None:
     """Ensure AsyncChatClient raises ConfigurationError if webhook is empty."""
-    with pytest.raises(ConfigurationError):
+    with pytest.raises(ValueError):
         AsyncChatClient(webhook_url="")
 
 
@@ -195,3 +205,4 @@ async def test_async_empty_message() -> None:
             ValueError, match="You must provide either 'text' or 'cards'"
         ):
             await client.send_message()
+

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -1,22 +1,20 @@
 # SPDX-License-Identifier: Apache-2.0
-"""
-Unit tests for chatapult.formatters helper functions.
-"""
-import pytest
+"""Unit tests for chatapult.formatters helper functions."""
+
 from chatapult.formatters import mention_all, mention_user
 
 
-def test_mention_all():
-    """mention_all() should return <users/all>"""
+def test_mention_all() -> None:
+    """mention_all() should return <users/all>."""
     assert mention_all() == "<users/all>"
 
 
-def test_mention_user():
-    """mention_user() should return <users/{user_id}>"""
+def test_mention_user() -> None:
+    """mention_user() should return <users/{user_id}>."""
     assert mention_user("12345") == "<users/12345>"
 
 
-def test_mention_user_different_ids():
+def test_mention_user_different_ids() -> None:
     """mention_user() should work with any user ID."""
     assert mention_user("abc") == "<users/abc>"
     assert mention_user("99999") == "<users/99999>"

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Unit tests for chatapult.formatters helper functions.
+"""
+import pytest
+from chatapult.formatters import mention_all, mention_user
+
+
+def test_mention_all():
+    """mention_all() should return <users/all>"""
+    assert mention_all() == "<users/all>"
+
+
+def test_mention_user():
+    """mention_user() should return <users/{user_id}>"""
+    assert mention_user("12345") == "<users/12345>"
+
+
+def test_mention_user_different_ids():
+    """mention_user() should work with any user ID."""
+    assert mention_user("abc") == "<users/abc>"
+    assert mention_user("99999") == "<users/99999>"


### PR DESCRIPTION
Closes #10

Added URL validation in `__init__` of both `ChatClient` 
and `AsyncChatClient`.

- Raises `ValueError` if URL is empty or doesn't start with
  `https://chat.googleapis.com/v1/spaces/`
- Updated existing tests to reflect new error type
- Added new tests for invalid URL format