### PR TITLE
feat(models): add Button and ButtonList widgets

### DIFF
--- a/src/chatapult/models.py
+++ b/src/chatapult/models.py
@@ -33,6 +33,48 @@ class TextParagraph(BaseModel):
 
 
 @dataclass
+class OpenLink(BaseModel):
+    """OpenLink action.
+
+    A link that opens when a widget is clicked.
+    """
+
+    url: str
+
+
+@dataclass
+class OnClick(BaseModel):
+    """OnClick action.
+
+    An action that happens when a user clicks a widget.
+    """
+
+    openLink: Optional[OpenLink] = None
+
+
+@dataclass
+class Button(BaseModel):
+    """Button widget.
+
+    A button that can be clicked
+    """
+
+    text: str
+    onClick: OnClick
+    # Can also be added an icon.
+
+
+@dataclass
+class ButtonList(BaseModel):
+    """ButtonList widget.
+
+    A list of buttons displayed.
+    """
+
+    buttons: List[Button] = field(default_factory=list)
+
+
+@dataclass
 class Widget(BaseModel):
     """Widget.
 
@@ -40,7 +82,8 @@ class Widget(BaseModel):
     """
 
     textParagraph: Optional[TextParagraph] = None
-    # Future widgets (Image, ButtonList, etc.) can be added here as Optional fields.
+    buttonList: Optional[ButtonList] = None
+    # More widgets (Eg: Images) can be added here as Optional fields.
 
 
 @dataclass

--- a/src/chatapult/models.py
+++ b/src/chatapult/models.py
@@ -56,7 +56,7 @@ class OnClick(BaseModel):
 class Button(BaseModel):
     """Button widget.
 
-    A button that can be clicked
+    A button that can be clicked.
     """
 
     text: str

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -7,6 +7,10 @@ from chatapult.models import (
     Section,
     Widget,
     TextParagraph,
+    OpenLink,
+    OnClick,
+    Button,
+    ButtonList,
 )
 
 
@@ -16,6 +20,46 @@ def test_text_paragraph_serialization() -> None:
     data = widget.to_dict()
 
     assert data == {"textParagraph": {"text": "Hello, Chat!"}}
+
+
+def test_button_list_serialization() -> None:
+    """Test that a button list with button and open link serializes correctly."""
+    open_link = OpenLink(url="https://github.com/DLambros91/chatapult")
+    on_click = OnClick(openLink=open_link)
+    button = Button(text="Chatapult Github", onClick=on_click)
+
+    widget = Widget(buttonList=ButtonList(buttons=[button]))
+
+    data = widget.to_dict()
+
+    assert data == {
+        "buttonList": {
+            "buttons": [
+                {
+                    "text": "Chatapult Github",
+                    "onClick": {
+                        "openLink": {"url": "https://github.com/DLambros91/chatapult"}
+                    },
+                }
+            ]
+        }
+    }
+
+
+def test_multiple_buttons_serialization() -> None:
+    """Test that multiple buttons in a buttonList are serialized."""
+    button1 = Button(
+        text="Button 1", onClick=OnClick(openLink=OpenLink(url="url_test1"))
+    )
+    button2 = Button(
+        text="Button 2", onClick=OnClick(openLink=OpenLink(url="url_test2"))
+    )
+
+    widget = Widget(buttonList=ButtonList(buttons=[button1, button2]))
+    data = widget.to_dict()
+
+    assert len(data["buttonList"]["buttons"]) == 2
+    assert data["buttonList"]["buttons"][1]["text"] == "Button 2"
 
 
 def test_card_serialization_drops_none() -> None:


### PR DESCRIPTION
Closes #20 

Implemented the necessary data models in order to support interactive buttons within the cards.

* Added `Button`, `ButtonList`, `OnClick`, and `OpenLink` to `models.py`.
* Updated the `Widget` class to include the optional `buttonList` field.

