### PR TITLE
feat(client): Added retry mechanism for client and async client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -210,3 +210,6 @@ __marimo__/
 # Intellij
 .idea/
 uv.lock
+
+# asdf
+.tool-versions

--- a/.gitignore
+++ b/.gitignore
@@ -206,3 +206,7 @@ marimo/_static/
 marimo/_lsp/
 __marimo__/
 .python-version
+
+# Intellij
+.idea/
+uv.lock

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
 # httpx handles both sync and async requests, keeping our footprint small.
 dependencies = [
     "httpx>=0.24.0",
+    "tenacity>=9.0.0",
 ]
 
 [project.optional-dependencies]
@@ -61,3 +62,8 @@ ignore = [
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"
+
+[dependency-groups]
+dev = [
+    "pre-commit>=3.5.0",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,10 @@ dev = [
 [tool.hatch.build.targets.wheel]
 packages = ["src/chatapult"]
 
+[tool.black]
+target-version = ["py38", "py39", "py310", "py311", "py312"]
+line-length = 88
+
 [tool.ruff]
 line-length = 88
 
@@ -62,8 +66,3 @@ ignore = [
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"
-
-[dependency-groups]
-dev = [
-    "pre-commit>=3.5.0",
-]

--- a/src/chatapult/__init__.py
+++ b/src/chatapult/__init__.py
@@ -13,6 +13,7 @@ from .exceptions import (
     ChatapultError,
     ConfigurationError,
     NetworkError,
+    RateLimitError,
 )
 
 # The __all__ list strictly defines the public API of your module.
@@ -25,4 +26,5 @@ __all__ = [
     "ChatapultError",
     "ConfigurationError",
     "NetworkError",
+    "RateLimitError",
 ]

--- a/src/chatapult/async_client.py
+++ b/src/chatapult/async_client.py
@@ -2,7 +2,13 @@ from typing import Any, Dict, Optional, List
 
 import httpx
 
-from .exceptions import APIError, ConfigurationError, NetworkError, RateLimitError
+from .exceptions import (
+    APIError,
+    ConfigurationError,
+    NetworkError,
+    RateLimitError,
+    ServerError,
+)
 from .models import CardWithId
 
 from .utils import retry_upon_rate_limit
@@ -45,6 +51,12 @@ class AsyncChatClient:
         """
         if not webhook_url:
             raise ConfigurationError("A valid webhook_url must be provided.")
+        if max_retries < 0:
+            raise ConfigurationError("max_retries must be >= 0.")
+        if retry_wait_min < 0:
+            raise ConfigurationError("retry_wait_min must be >= 0.")
+        if retry_wait_max < retry_wait_min:
+            raise ConfigurationError("retry_wait_max must be >= retry_wait_min.")
 
         self.webhook_url = webhook_url
         self._client = httpx.AsyncClient(timeout=timeout)
@@ -90,6 +102,12 @@ class AsyncChatClient:
                 if e.response.status_code == 429:
                     raise RateLimitError(
                         f"Google Chat API rate limited (429): {e.response.text}",
+                        response=e.response,
+                    ) from e
+                if e.response.status_code >= 500:
+                    raise ServerError(
+                        f"Google Chat API server error "
+                        f"({e.response.status_code}): {e.response.text}",
                         response=e.response,
                     ) from e
                 raise APIError(

--- a/src/chatapult/async_client.py
+++ b/src/chatapult/async_client.py
@@ -2,8 +2,10 @@ from typing import Any, Dict, Optional, List
 
 import httpx
 
-from .exceptions import APIError, ConfigurationError, NetworkError
+from .exceptions import APIError, ConfigurationError, NetworkError, RateLimitError
 from .models import CardWithId
+
+from .utils import retry_upon_rate_limit
 
 
 class AsyncChatClient:
@@ -13,21 +15,42 @@ class AsyncChatClient:
     loop.
     """
 
-    def __init__(self, webhook_url: str, timeout: float = 10.0) -> None:
+    def __init__(
+        self,
+        webhook_url: str,
+        timeout: float = 10.0,
+        max_retries: int = 3,
+        retry_wait_min: float = 1.0,
+        retry_wait_max: float = 60.0,
+    ) -> None:
         """Initialize the AsyncChatClient.
 
+        Configures an HTTP client and retry mechanism for
+        sending messages to a Google Chat webhook.
+
         Args:
-            webhook_url (str): The full Google Chat webhook URL.
-            timeout (float): Connection timeout in seconds. Defaults to 10.0.
+            webhook_url: The URL of the webhook to interact with.
+            timeout: Timeout for HTTP requests in seconds.
+                Defaults to 10.0.
+            max_retries: Maximum number of retry attempts.
+                Defaults to 3.
+            retry_wait_min: Minimum wait between retries in
+                seconds. Defaults to 1.0.
+            retry_wait_max: Maximum wait between retries in
+                seconds. Defaults to 60.0.
 
         Raises:
-            ConfigurationError: If the webhook_url is empty.
+            ConfigurationError: If the provided webhook_url is
+                invalid or not provided.
         """
         if not webhook_url:
             raise ConfigurationError("A valid webhook_url must be provided.")
 
         self.webhook_url = webhook_url
         self._client = httpx.AsyncClient(timeout=timeout)
+        self._max_retries = max_retries
+        self._retry_wait_min = retry_wait_min
+        self._retry_wait_max = retry_wait_max
 
     async def send_message(
         self,
@@ -53,17 +76,32 @@ class AsyncChatClient:
         if thread_name:
             payload["thread"] = {"name": thread_name}
 
-        try:
-            response = await self._client.post(self.webhook_url, json=payload)
-            response.raise_for_status()
-            return response.json()
-        except httpx.HTTPStatusError as e:
-            raise APIError(
-                f"Google Chat API returned {e.response.status_code}: {e.response.text}",
-                response=e.response,
-            ) from e
-        except httpx.RequestError as e:
-            raise NetworkError(f"Network error while sending message: {e}") from e
+        @retry_upon_rate_limit(
+            max_retries=self._max_retries,
+            retry_wait_max=self._retry_wait_max,
+            retry_wait_min=self._retry_wait_min,
+        )
+        async def do_async_post() -> Dict[str, Any]:
+            try:
+                response = await self._client.post(self.webhook_url, json=payload)
+                response.raise_for_status()
+                return response.json()
+            except httpx.HTTPStatusError as e:
+                if e.response.status_code == 429:
+                    raise RateLimitError(
+                        f"Google Chat API rate limited (429): {e.response.text}",
+                        response=e.response,
+                    ) from e
+                raise APIError(
+                    f"Google Chat API returned "
+                    f"{e.response.status_code}: "
+                    f"{e.response.text}",
+                    response=e.response,
+                ) from e
+            except httpx.RequestError as e:
+                raise NetworkError(f"Network error while sending message: {e}") from e
+
+        return await do_async_post()
 
     async def aclose(self) -> None:
         """Close the underlying asynchronous HTTP client connections."""

--- a/src/chatapult/client.py
+++ b/src/chatapult/client.py
@@ -3,7 +3,13 @@ from typing import Any, Dict, Optional, List
 import httpx
 
 # Import our new custom exceptions
-from .exceptions import APIError, ConfigurationError, NetworkError, RateLimitError
+from .exceptions import (
+    APIError,
+    ConfigurationError,
+    NetworkError,
+    RateLimitError,
+    ServerError,
+)
 from .models import CardWithId
 
 from .utils import retry_upon_rate_limit
@@ -50,6 +56,12 @@ class ChatClient:
         """
         if not webhook_url:
             raise ConfigurationError("A valid webhook_url must be provided.")
+        if max_retries < 0:
+            raise ConfigurationError("max_retries must be >= 0.")
+        if retry_wait_min < 0:
+            raise ConfigurationError("retry_wait_min must be >= 0.")
+        if retry_wait_max < retry_wait_min:
+            raise ConfigurationError("retry_wait_max must be >= retry_wait_min.")
 
         self.webhook_url = webhook_url
         self._client = httpx.Client(timeout=timeout)
@@ -102,6 +114,12 @@ class ChatClient:
                 if e.response.status_code == 429:
                     raise RateLimitError(
                         f"Google Chat API rate limited (429): {e.response.text}",
+                        response=e.response,
+                    ) from e
+                if e.response.status_code >= 500:
+                    raise ServerError(
+                        f"Google Chat API server error "
+                        f"({e.response.status_code}): {e.response.text}",
                         response=e.response,
                     ) from e
                 raise APIError(

--- a/src/chatapult/client.py
+++ b/src/chatapult/client.py
@@ -3,8 +3,10 @@ from typing import Any, Dict, Optional, List
 import httpx
 
 # Import our new custom exceptions
-from .exceptions import APIError, ConfigurationError, NetworkError
+from .exceptions import APIError, ConfigurationError, NetworkError, RateLimitError
 from .models import CardWithId
+
+from .utils import retry_upon_rate_limit
 
 
 class ChatClient:
@@ -13,21 +15,47 @@ class ChatClient:
     This client uses httpx's Client to send messages in a blocking manner.
     """
 
-    def __init__(self, webhook_url: str, timeout: float = 10.0) -> None:
+    def __init__(
+        self,
+        webhook_url: str,
+        timeout: float = 10.0,
+        max_retries: int = 3,
+        retry_wait_min: float = 1.0,
+        retry_wait_max: float = 60.0,
+    ) -> None:
         """Initialize the ChatClient.
 
+        Configures HTTP client and retry mechanism for sending
+        messages to a Google Chat webhook.
+
+        Attributes:
+            webhook_url: The URL of the webhook to which
+                requests will be sent.
+
         Args:
-            webhook_url (str): The full Google Chat webhook URL.
-            timeout (float): Connection timeout in seconds. Defaults to 10.0.
+            webhook_url: The webhook URL as a string. Must be
+                a valid and non-empty URL.
+            timeout: Timeout for HTTP requests in seconds.
+                Defaults to 10.0.
+            max_retries: Maximum number of retries for failed
+                requests. Defaults to 3.
+            retry_wait_min: Minimum wait time between retries
+                in seconds. Defaults to 1.0.
+            retry_wait_max: Maximum wait time between retries
+                in seconds. Defaults to 60.0.
 
         Raises:
-            ConfigurationError: If the webhook_url is empty or invalid.
+            ConfigurationError: If an invalid or empty
+                webhook_url is provided.
         """
         if not webhook_url:
             raise ConfigurationError("A valid webhook_url must be provided.")
 
         self.webhook_url = webhook_url
         self._client = httpx.Client(timeout=timeout)
+        self._max_retries = max_retries
+        self._retry_wait_min = retry_wait_min
+        self._retry_wait_max = retry_wait_max
 
     def send_message(
         self,
@@ -60,17 +88,32 @@ class ChatClient:
         if thread_name:
             payload["thread"] = {"name": thread_name}
 
-        try:
-            response = self._client.post(self.webhook_url, json=payload)
-            response.raise_for_status()
-            return response.json()
-        except httpx.HTTPStatusError as e:
-            raise APIError(
-                f"Google Chat API returned {e.response.status_code}: {e.response.text}",
-                response=e.response,
-            ) from e
-        except httpx.RequestError as e:
-            raise NetworkError(f"Network error while sending message: {e}") from e
+        @retry_upon_rate_limit(
+            max_retries=self._max_retries,
+            retry_wait_max=self._retry_wait_max,
+            retry_wait_min=self._retry_wait_min,
+        )
+        def _do_post() -> Dict[str, Any]:
+            try:
+                response = self._client.post(self.webhook_url, json=payload)
+                response.raise_for_status()
+                return response.json()
+            except httpx.HTTPStatusError as e:
+                if e.response.status_code == 429:
+                    raise RateLimitError(
+                        f"Google Chat API rate limited (429): {e.response.text}",
+                        response=e.response,
+                    ) from e
+                raise APIError(
+                    f"Google Chat API returned "
+                    f"{e.response.status_code}: "
+                    f"{e.response.text}",
+                    response=e.response,
+                ) from e
+            except httpx.RequestError as e:
+                raise NetworkError(f"Network error while sending message: {e}") from e
+
+        return _do_post()
 
     def close(self) -> None:
         """Close the underlying HTTP client connections."""

--- a/src/chatapult/exceptions.py
+++ b/src/chatapult/exceptions.py
@@ -41,3 +41,33 @@ class APIError(ChatapultError):
         super().__init__(message)
         self.response = response
         self.status_code = response.status_code if response is not None else None
+
+
+class RateLimitError(APIError):
+    """Raised when the Google Chat API returns a 429 Too Many Requests status."""
+
+    def __init__(self, message: str, response: Optional[httpx.Response] = None) -> None:
+        """Initialize the RateLimitError.
+
+        Includes optional retry delay information based on
+        a response.
+
+        Attributes:
+            retry_after: The number of seconds to wait before
+                retrying if provided by the response.
+
+        Args:
+            message: The error message for the exception.
+            response: An optional HTTP response object
+                associated with this exception.
+        """
+        super().__init__(message, response=response)
+        self.retry_after: Optional[float] = None
+        if response is not None:
+            # checking if headers are coming from google chat or not
+            raw = response.headers.get("Retry-After")
+            if raw is not None:
+                try:
+                    self.retry_after = float(raw)
+                except ValueError:
+                    self.retry_after = None

--- a/src/chatapult/exceptions.py
+++ b/src/chatapult/exceptions.py
@@ -4,7 +4,9 @@ This module defines a hierarchy of exceptions that can be raised by the Chatapul
 clients.
 """
 
+from email.utils import parsedate_to_datetime
 from typing import Optional
+import datetime
 
 import httpx
 
@@ -43,6 +45,35 @@ class APIError(ChatapultError):
         self.status_code = response.status_code if response is not None else None
 
 
+def _parse_retry_after(value: str) -> Optional[float]:
+    """Parse a Retry-After header value into a non-negative delay in seconds.
+
+    Supports both the delay-seconds form (e.g. ``"30"``) and the HTTP-date
+    form (e.g. ``"Thu, 01 Jan 2026 00:00:00 GMT"``).  Negative delay-seconds
+    values are clamped to 0.  Returns ``None`` when the value cannot be
+    parsed.
+
+    Args:
+        value: The stripped Retry-After header string.
+
+    Returns:
+        Seconds to wait as a non-negative float, or ``None`` if unparseable.
+    """
+    # Try delay-seconds form first.
+    try:
+        return max(0.0, float(value))
+    except ValueError:
+        pass
+
+    # Try HTTP-date form (RFC 7231).
+    try:
+        retry_date = parsedate_to_datetime(value)
+        now = datetime.datetime.now(datetime.timezone.utc)
+        return max(0.0, (retry_date - now).total_seconds())
+    except Exception:
+        return None
+
+
 class RateLimitError(APIError):
     """Raised when the Google Chat API returns a 429 Too Many Requests status."""
 
@@ -64,10 +95,12 @@ class RateLimitError(APIError):
         super().__init__(message, response=response)
         self.retry_after: Optional[float] = None
         if response is not None:
-            # checking if headers are coming from google chat or not
             raw = response.headers.get("Retry-After")
             if raw is not None:
-                try:
-                    self.retry_after = float(raw)
-                except ValueError:
-                    self.retry_after = None
+                self.retry_after = _parse_retry_after(raw.strip())
+
+
+class ServerError(APIError):
+    """Raised when the API returns a 5xx server error status."""
+
+    pass

--- a/src/chatapult/utils/__init__.py
+++ b/src/chatapult/utils/__init__.py
@@ -1,1 +1,3 @@
-from .rate_limit_utils import retry_upon_rate_limit as retry_upon_rate_limit
+from .rate_limit_utils import retry_upon_rate_limit
+
+__all__ = ["retry_upon_rate_limit"]

--- a/src/chatapult/utils/__init__.py
+++ b/src/chatapult/utils/__init__.py
@@ -1,0 +1,1 @@
+from .rate_limit_utils import retry_upon_rate_limit as retry_upon_rate_limit

--- a/src/chatapult/utils/rate_limit_utils.py
+++ b/src/chatapult/utils/rate_limit_utils.py
@@ -6,7 +6,7 @@ from tenacity import (
     RetryCallState,
 )
 
-from chatapult.exceptions import RateLimitError
+from chatapult.exceptions import RateLimitError, ServerError
 
 
 def retry_upon_rate_limit(
@@ -19,7 +19,7 @@ def retry_upon_rate_limit(
     parameters. If the raised error provides a ``retry_after``
     duration, that value is used as the wait time instead.
 
-    Parameters:
+    Args:
         max_retries (int): The maximum number of retry
             attempts allowed. Must be a positive integer.
         retry_wait_min (float): The minimum wait time
@@ -66,7 +66,7 @@ def retry_upon_rate_limit(
         return wait_exponential(min=retry_wait_min, max=retry_wait_max)(retry_state)
 
     return retry(
-        retry=retry_if_exception_type(RateLimitError),
+        retry=retry_if_exception_type((RateLimitError, ServerError)),
         wait=_wait_with_rate_limit,
         stop=stop_after_attempt(max_retries + 1),
         reraise=True,

--- a/src/chatapult/utils/rate_limit_utils.py
+++ b/src/chatapult/utils/rate_limit_utils.py
@@ -1,0 +1,73 @@
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+    RetryCallState,
+)
+
+from chatapult.exceptions import RateLimitError
+
+
+def retry_upon_rate_limit(
+    max_retries: int, retry_wait_min: float, retry_wait_max: float
+):
+    """Create a retry decorator for rate limit errors.
+
+    Retries execution of a callable upon encountering a
+    RateLimitError, using exponential backoff with configurable
+    parameters. If the raised error provides a ``retry_after``
+    duration, that value is used as the wait time instead.
+
+    Parameters:
+        max_retries (int): The maximum number of retry
+            attempts allowed. Must be a positive integer.
+        retry_wait_min (float): The minimum wait time
+            (in seconds) between retry attempts. Must be
+            a non-negative floating-point value.
+        retry_wait_max (float): The maximum wait time
+            (in seconds) between retry attempts. Must be
+            greater than or equal to ``retry_wait_min``.
+
+    Returns:
+        Callable: A configured retry object that wraps a
+        callable for retrying on rate limit errors.
+
+    Raises:
+        The original exception will be re-raised if all
+        retry attempts are exhausted.
+    """
+
+    def _wait_with_rate_limit(retry_state: RetryCallState) -> float:
+        """Wait function with rate limit error handling.
+
+        Determines the wait time before retrying a call. If
+        the outcome contains a RateLimitError with a
+        ``retry_after`` value, that value is used. Otherwise,
+        exponential backoff is applied using the configured
+        minimum and maximum wait durations.
+
+        Args:
+            retry_state (RetryCallState): The state of
+                the retry, including the outcome of the
+                previous attempt.
+
+        Returns:
+            float: Seconds to wait before the next retry.
+        """
+        if retry_state.outcome is not None:
+            exception_caught = retry_state.outcome.exception()
+            if (
+                isinstance(exception_caught, RateLimitError)
+                and exception_caught.retry_after is not None
+            ):
+                return exception_caught.retry_after
+
+        return wait_exponential(min=retry_wait_min, max=retry_wait_max)(retry_state)
+
+    return retry(
+        retry=retry_if_exception_type(RateLimitError),
+        wait=_wait_with_rate_limit,
+        stop=stop_after_attempt(max_retries + 1),
+        reraise=True,
+    )

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -5,7 +5,12 @@ from pytest_httpx import HTTPXMock
 
 from chatapult.client import ChatClient
 from chatapult.async_client import AsyncChatClient
-from chatapult.exceptions import APIError, ConfigurationError, NetworkError
+from chatapult.exceptions import (
+    APIError,
+    ConfigurationError,
+    NetworkError,
+    RateLimitError,
+)
 from chatapult.models import CardWithId, Card
 
 # Dummy webhook URL for testing
@@ -108,6 +113,149 @@ def test_sync_empty_message() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Synchronous Client Retry Tests (429 Rate Limiting)
+# ---------------------------------------------------------------------------
+
+
+def test_sync_rate_limit_raises_rate_limit_error(httpx_mock: HTTPXMock) -> None:
+    """Test that a 429 response raises RateLimitError, not generic APIError."""
+    httpx_mock.add_response(status_code=429, text="Too Many Requests")
+
+    with ChatClient(
+        WEBHOOK_URL, max_retries=0, retry_wait_min=0, retry_wait_max=0
+    ) as client:
+        with pytest.raises(RateLimitError) as exc_info:
+            client.send_message("This will be rate limited")
+
+    assert exc_info.value.status_code == 429
+    assert "429" in str(exc_info.value)
+    assert "Too Many Requests" in str(exc_info.value)
+
+
+def test_sync_rate_limit_is_api_error_subclass(httpx_mock: HTTPXMock) -> None:
+    """Test that RateLimitError is catchable as APIError (subclass relationship)."""
+    httpx_mock.add_response(status_code=429, text="Too Many Requests")
+
+    with ChatClient(
+        WEBHOOK_URL, max_retries=0, retry_wait_min=0, retry_wait_max=0
+    ) as client:
+        with pytest.raises(APIError) as exc_info:
+            client.send_message("This will be rate limited")
+
+    assert isinstance(exc_info.value, RateLimitError)
+    assert exc_info.value.status_code == 429
+
+
+def test_sync_rate_limit_retry_succeeds(httpx_mock: HTTPXMock) -> None:
+    """Test that a transient 429 followed by a 200 succeeds after retry."""
+    # First request → 429, second request → 200
+    httpx_mock.add_response(status_code=429, text="Too Many Requests")
+    httpx_mock.add_response(
+        status_code=200, json={"name": "spaces/SPACE/messages/MSG", "text": "OK"}
+    )
+
+    with ChatClient(
+        WEBHOOK_URL, max_retries=1, retry_wait_min=0, retry_wait_max=0
+    ) as client:
+        response = client.send_message("Retry me")
+
+    assert response == {"name": "spaces/SPACE/messages/MSG", "text": "OK"}
+
+    # Verify two requests were made (original + 1 retry)
+    requests = httpx_mock.get_requests()
+    assert len(requests) == 2
+
+
+def test_sync_rate_limit_multiple_retries_then_success(httpx_mock: HTTPXMock) -> None:
+    """Test that multiple consecutive 429s are retried until success."""
+    # Two 429s, then success
+    httpx_mock.add_response(status_code=429, text="Too Many Requests")
+    httpx_mock.add_response(status_code=429, text="Too Many Requests")
+    httpx_mock.add_response(status_code=200, json={"text": "Finally!"})
+
+    with ChatClient(
+        WEBHOOK_URL, max_retries=2, retry_wait_min=0, retry_wait_max=0
+    ) as client:
+        response = client.send_message("Retry me twice")
+
+    assert response == {"text": "Finally!"}
+
+    # Verify three requests were made (original + 2 retries)
+    requests = httpx_mock.get_requests()
+    assert len(requests) == 3
+
+
+def test_sync_rate_limit_retry_exhausted(httpx_mock: HTTPXMock) -> None:
+    """Test that RateLimitError is raised after all retries are exhausted."""
+    # All attempts return 429
+    httpx_mock.add_response(status_code=429, text="Too Many Requests")
+    httpx_mock.add_response(status_code=429, text="Still Too Many")
+    httpx_mock.add_response(status_code=429, text="Still Too Many")
+
+    with ChatClient(
+        WEBHOOK_URL, max_retries=2, retry_wait_min=0, retry_wait_max=0
+    ) as client:
+        with pytest.raises(RateLimitError) as exc_info:
+            client.send_message("This will exhaust retries")
+
+    assert exc_info.value.status_code == 429
+
+    # Verify all attempts were made (original + 2 retries)
+    requests = httpx_mock.get_requests()
+    assert len(requests) == 3
+
+
+def test_sync_rate_limit_retry_after_header(httpx_mock: HTTPXMock) -> None:
+    """Test that the Retry-After header value is parsed into RateLimitError."""
+    httpx_mock.add_response(
+        status_code=429,
+        text="Too Many Requests",
+        headers={"Retry-After": "5"},
+    )
+
+    with ChatClient(
+        WEBHOOK_URL, max_retries=0, retry_wait_min=0, retry_wait_max=0
+    ) as client:
+        with pytest.raises(RateLimitError) as exc_info:
+            client.send_message("Check retry-after")
+
+    assert exc_info.value.retry_after == 5.0
+    assert exc_info.value.status_code == 429
+
+
+def test_sync_rate_limit_retry_after_header_missing(httpx_mock: HTTPXMock) -> None:
+    """Test that retry_after is None when Retry-After header is absent."""
+    httpx_mock.add_response(status_code=429, text="Too Many Requests")
+
+    with ChatClient(
+        WEBHOOK_URL, max_retries=0, retry_wait_min=0, retry_wait_max=0
+    ) as client:
+        with pytest.raises(RateLimitError) as exc_info:
+            client.send_message("No retry-after header")
+
+    assert exc_info.value.retry_after is None
+
+
+def test_sync_non_429_error_not_retried(httpx_mock: HTTPXMock) -> None:
+    """Test that non-429 errors (e.g. 400, 500) are NOT retried."""
+    httpx_mock.add_response(status_code=400, text="Bad Request")
+
+    with ChatClient(
+        WEBHOOK_URL, max_retries=2, retry_wait_min=0, retry_wait_max=0
+    ) as client:
+        with pytest.raises(APIError) as exc_info:
+            client.send_message("This is a bad request")
+
+    # Should NOT be a RateLimitError
+    assert not isinstance(exc_info.value, RateLimitError)
+    assert exc_info.value.status_code == 400
+
+    # Only one request — no retries for non-429 errors
+    requests = httpx_mock.get_requests()
+    assert len(requests) == 1
+
+
+# ---------------------------------------------------------------------------
 # Asynchronous Client Tests
 # ---------------------------------------------------------------------------
 
@@ -195,3 +343,150 @@ async def test_async_empty_message() -> None:
             ValueError, match="You must provide either 'text' or 'cards'"
         ):
             await client.send_message()
+
+
+# ---------------------------------------------------------------------------
+# Asynchronous Client Retry Tests (429 Rate Limiting)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_async_rate_limit_raises_rate_limit_error(httpx_mock: HTTPXMock) -> None:
+    """Test that a 429 response raises RateLimitError (async)."""
+    httpx_mock.add_response(status_code=429, text="Too Many Requests")
+
+    async with AsyncChatClient(
+        WEBHOOK_URL, max_retries=0, retry_wait_min=0, retry_wait_max=0
+    ) as client:
+        with pytest.raises(RateLimitError) as exc_info:
+            await client.send_message("This will be rate limited")
+
+    assert exc_info.value.status_code == 429
+    assert "429" in str(exc_info.value)
+    assert "Too Many Requests" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_async_rate_limit_is_api_error_subclass(httpx_mock: HTTPXMock) -> None:
+    """Test that RateLimitError is catchable as APIError (async)."""
+    httpx_mock.add_response(status_code=429, text="Too Many Requests")
+
+    async with AsyncChatClient(
+        WEBHOOK_URL, max_retries=0, retry_wait_min=0, retry_wait_max=0
+    ) as client:
+        with pytest.raises(APIError) as exc_info:
+            await client.send_message("This will be rate limited")
+
+    assert isinstance(exc_info.value, RateLimitError)
+    assert exc_info.value.status_code == 429
+
+
+@pytest.mark.asyncio
+async def test_async_rate_limit_retry_succeeds(httpx_mock: HTTPXMock) -> None:
+    """Test that a transient 429 followed by a 200 succeeds after retry (async)."""
+    httpx_mock.add_response(status_code=429, text="Too Many Requests")
+    httpx_mock.add_response(
+        status_code=200, json={"name": "spaces/SPACE/messages/MSG", "text": "OK"}
+    )
+
+    async with AsyncChatClient(
+        WEBHOOK_URL, max_retries=1, retry_wait_min=0, retry_wait_max=0
+    ) as client:
+        response = await client.send_message("Retry me")
+
+    assert response == {"name": "spaces/SPACE/messages/MSG", "text": "OK"}
+
+    requests = httpx_mock.get_requests()
+    assert len(requests) == 2
+
+
+@pytest.mark.asyncio
+async def test_async_rate_limit_multiple_retries_then_success(
+    httpx_mock: HTTPXMock,
+) -> None:
+    """Test that multiple consecutive 429s are retried until success (async)."""
+    httpx_mock.add_response(status_code=429, text="Too Many Requests")
+    httpx_mock.add_response(status_code=429, text="Too Many Requests")
+    httpx_mock.add_response(status_code=200, json={"text": "Finally!"})
+
+    async with AsyncChatClient(
+        WEBHOOK_URL, max_retries=2, retry_wait_min=0, retry_wait_max=0
+    ) as client:
+        response = await client.send_message("Retry me twice")
+
+    assert response == {"text": "Finally!"}
+
+    requests = httpx_mock.get_requests()
+    assert len(requests) == 3
+
+
+@pytest.mark.asyncio
+async def test_async_rate_limit_retry_exhausted(httpx_mock: HTTPXMock) -> None:
+    """Test that RateLimitError is raised after all retries are exhausted (async)."""
+    httpx_mock.add_response(status_code=429, text="Too Many Requests")
+    httpx_mock.add_response(status_code=429, text="Still Too Many")
+    httpx_mock.add_response(status_code=429, text="Still Too Many")
+
+    async with AsyncChatClient(
+        WEBHOOK_URL, max_retries=2, retry_wait_min=0, retry_wait_max=0
+    ) as client:
+        with pytest.raises(RateLimitError) as exc_info:
+            await client.send_message("This will exhaust retries")
+
+    assert exc_info.value.status_code == 429
+
+    requests = httpx_mock.get_requests()
+    assert len(requests) == 3
+
+
+@pytest.mark.asyncio
+async def test_async_rate_limit_retry_after_header(httpx_mock: HTTPXMock) -> None:
+    """Test that the Retry-After header value is parsed into RateLimitError (async)."""
+    httpx_mock.add_response(
+        status_code=429,
+        text="Too Many Requests",
+        headers={"Retry-After": "5"},
+    )
+
+    async with AsyncChatClient(
+        WEBHOOK_URL, max_retries=0, retry_wait_min=0, retry_wait_max=0
+    ) as client:
+        with pytest.raises(RateLimitError) as exc_info:
+            await client.send_message("Check retry-after")
+
+    assert exc_info.value.retry_after == 5.0
+    assert exc_info.value.status_code == 429
+
+
+@pytest.mark.asyncio
+async def test_async_rate_limit_retry_after_header_missing(
+    httpx_mock: HTTPXMock,
+) -> None:
+    """Test that retry_after is None when Retry-After header is absent (async)."""
+    httpx_mock.add_response(status_code=429, text="Too Many Requests")
+
+    async with AsyncChatClient(
+        WEBHOOK_URL, max_retries=0, retry_wait_min=0, retry_wait_max=0
+    ) as client:
+        with pytest.raises(RateLimitError) as exc_info:
+            await client.send_message("No retry-after header")
+
+    assert exc_info.value.retry_after is None
+
+
+@pytest.mark.asyncio
+async def test_async_non_429_error_not_retried(httpx_mock: HTTPXMock) -> None:
+    """Test that non-429 errors are NOT retried (async)."""
+    httpx_mock.add_response(status_code=400, text="Bad Request")
+
+    async with AsyncChatClient(
+        WEBHOOK_URL, max_retries=2, retry_wait_min=0, retry_wait_max=0
+    ) as client:
+        with pytest.raises(APIError) as exc_info:
+            await client.send_message("This is a bad request")
+
+    assert not isinstance(exc_info.value, RateLimitError)
+    assert exc_info.value.status_code == 400
+
+    requests = httpx_mock.get_requests()
+    assert len(requests) == 1

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -1,3 +1,4 @@
+import datetime
 import httpx
 import json
 import pytest
@@ -10,6 +11,7 @@ from chatapult.exceptions import (
     ConfigurationError,
     NetworkError,
     RateLimitError,
+    ServerError,
 )
 from chatapult.models import CardWithId, Card
 
@@ -28,6 +30,24 @@ def test_sync_client_init_empty_url() -> None:
     """Ensure ChatClient raises ConfigurationError if webhook is empty."""
     with pytest.raises(ConfigurationError):
         ChatClient(webhook_url="")
+
+
+def test_sync_client_init_negative_max_retries() -> None:
+    """Ensure ChatClient raises ConfigurationError for negative max_retries."""
+    with pytest.raises(ConfigurationError, match="max_retries"):
+        ChatClient(WEBHOOK_URL, max_retries=-1)
+
+
+def test_sync_client_init_negative_retry_wait_min() -> None:
+    """Ensure ChatClient raises ConfigurationError for negative retry_wait_min."""
+    with pytest.raises(ConfigurationError, match="retry_wait_min"):
+        ChatClient(WEBHOOK_URL, retry_wait_min=-1.0)
+
+
+def test_sync_client_init_retry_wait_max_less_than_min() -> None:
+    """Ensure ChatClient raises ConfigurationError when max < min wait."""
+    with pytest.raises(ConfigurationError, match="retry_wait_max"):
+        ChatClient(WEBHOOK_URL, retry_wait_min=10.0, retry_wait_max=5.0)
 
 
 def test_sync_send_message_success(httpx_mock: HTTPXMock) -> None:
@@ -236,8 +256,64 @@ def test_sync_rate_limit_retry_after_header_missing(httpx_mock: HTTPXMock) -> No
     assert exc_info.value.retry_after is None
 
 
+def test_sync_rate_limit_retry_after_negative_clamped(httpx_mock: HTTPXMock) -> None:
+    """Test that a negative delay-seconds value is clamped to 0."""
+    httpx_mock.add_response(
+        status_code=429,
+        text="Too Many Requests",
+        headers={"Retry-After": "-10"},
+    )
+
+    with ChatClient(
+        WEBHOOK_URL, max_retries=0, retry_wait_min=0, retry_wait_max=0
+    ) as client:
+        with pytest.raises(RateLimitError) as exc_info:
+            client.send_message("Negative retry-after")
+
+    assert exc_info.value.retry_after == 0.0
+
+
+def test_sync_rate_limit_retry_after_http_date(httpx_mock: HTTPXMock) -> None:
+    """Test that an HTTP-date Retry-After value is parsed to a non-negative delay."""
+    future = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(
+        seconds=30
+    )
+    http_date = future.strftime("%a, %d %b %Y %H:%M:%S GMT")
+    httpx_mock.add_response(
+        status_code=429,
+        text="Too Many Requests",
+        headers={"Retry-After": http_date},
+    )
+
+    with ChatClient(
+        WEBHOOK_URL, max_retries=0, retry_wait_min=0, retry_wait_max=0
+    ) as client:
+        with pytest.raises(RateLimitError) as exc_info:
+            client.send_message("HTTP-date retry-after")
+
+    assert exc_info.value.retry_after is not None
+    assert exc_info.value.retry_after >= 0.0
+
+
+def test_sync_rate_limit_retry_after_unparseable(httpx_mock: HTTPXMock) -> None:
+    """Test that an unparseable Retry-After value results in retry_after=None."""
+    httpx_mock.add_response(
+        status_code=429,
+        text="Too Many Requests",
+        headers={"Retry-After": "not-a-valid-value"},
+    )
+
+    with ChatClient(
+        WEBHOOK_URL, max_retries=0, retry_wait_min=0, retry_wait_max=0
+    ) as client:
+        with pytest.raises(RateLimitError) as exc_info:
+            client.send_message("Unparseable retry-after")
+
+    assert exc_info.value.retry_after is None
+
+
 def test_sync_non_429_error_not_retried(httpx_mock: HTTPXMock) -> None:
-    """Test that non-429 errors (e.g. 400, 500) are NOT retried."""
+    """Test that non-retryable errors (e.g. 400) are NOT retried."""
     httpx_mock.add_response(status_code=400, text="Bad Request")
 
     with ChatClient(
@@ -250,7 +326,111 @@ def test_sync_non_429_error_not_retried(httpx_mock: HTTPXMock) -> None:
     assert not isinstance(exc_info.value, RateLimitError)
     assert exc_info.value.status_code == 400
 
-    # Only one request — no retries for non-429 errors
+    # Only one request — no retries for 4xx errors
+    requests = httpx_mock.get_requests()
+    assert len(requests) == 1
+
+
+# ---------------------------------------------------------------------------
+# Synchronous Client Retry Tests (5xx Server Errors)
+# ---------------------------------------------------------------------------
+
+
+def test_sync_server_error_raises_server_error(httpx_mock: HTTPXMock) -> None:
+    """Test that a 500 response raises ServerError, not generic APIError."""
+    httpx_mock.add_response(status_code=500, text="Internal Server Error")
+
+    with ChatClient(
+        WEBHOOK_URL, max_retries=0, retry_wait_min=0, retry_wait_max=0
+    ) as client:
+        with pytest.raises(ServerError) as exc_info:
+            client.send_message("This will fail with 500")
+
+    assert exc_info.value.status_code == 500
+    assert "500" in str(exc_info.value)
+    assert "Internal Server Error" in str(exc_info.value)
+
+
+def test_sync_server_error_is_api_error_subclass(httpx_mock: HTTPXMock) -> None:
+    """Test that ServerError is catchable as APIError (subclass relationship)."""
+    httpx_mock.add_response(status_code=503, text="Service Unavailable")
+
+    with ChatClient(
+        WEBHOOK_URL, max_retries=0, retry_wait_min=0, retry_wait_max=0
+    ) as client:
+        with pytest.raises(APIError) as exc_info:
+            client.send_message("This will fail with 503")
+
+    assert isinstance(exc_info.value, ServerError)
+    assert exc_info.value.status_code == 503
+
+
+def test_sync_server_error_retry_succeeds(httpx_mock: HTTPXMock) -> None:
+    """Test that a transient 500 followed by a 200 succeeds after retry."""
+    httpx_mock.add_response(status_code=500, text="Internal Server Error")
+    httpx_mock.add_response(
+        status_code=200, json={"name": "spaces/SPACE/messages/MSG", "text": "OK"}
+    )
+
+    with ChatClient(
+        WEBHOOK_URL, max_retries=1, retry_wait_min=0, retry_wait_max=0
+    ) as client:
+        response = client.send_message("Retry me")
+
+    assert response == {"name": "spaces/SPACE/messages/MSG", "text": "OK"}
+
+    requests = httpx_mock.get_requests()
+    assert len(requests) == 2
+
+
+def test_sync_server_error_multiple_retries_then_success(httpx_mock: HTTPXMock) -> None:
+    """Test that multiple consecutive 5xx responses are retried until success."""
+    httpx_mock.add_response(status_code=502, text="Bad Gateway")
+    httpx_mock.add_response(status_code=503, text="Service Unavailable")
+    httpx_mock.add_response(status_code=200, json={"text": "Finally!"})
+
+    with ChatClient(
+        WEBHOOK_URL, max_retries=2, retry_wait_min=0, retry_wait_max=0
+    ) as client:
+        response = client.send_message("Retry me twice")
+
+    assert response == {"text": "Finally!"}
+
+    requests = httpx_mock.get_requests()
+    assert len(requests) == 3
+
+
+def test_sync_server_error_retry_exhausted(httpx_mock: HTTPXMock) -> None:
+    """Test that ServerError is raised after all retries are exhausted."""
+    httpx_mock.add_response(status_code=500, text="Internal Server Error")
+    httpx_mock.add_response(status_code=500, text="Internal Server Error")
+    httpx_mock.add_response(status_code=500, text="Internal Server Error")
+
+    with ChatClient(
+        WEBHOOK_URL, max_retries=2, retry_wait_min=0, retry_wait_max=0
+    ) as client:
+        with pytest.raises(ServerError) as exc_info:
+            client.send_message("This will exhaust retries")
+
+    assert exc_info.value.status_code == 500
+
+    requests = httpx_mock.get_requests()
+    assert len(requests) == 3
+
+
+def test_sync_4xx_not_retried_but_5xx_is(httpx_mock: HTTPXMock) -> None:
+    """Test that 4xx errors (except 429) are not retried while 5xx would be."""
+    httpx_mock.add_response(status_code=403, text="Forbidden")
+
+    with ChatClient(
+        WEBHOOK_URL, max_retries=2, retry_wait_min=0, retry_wait_max=0
+    ) as client:
+        with pytest.raises(APIError) as exc_info:
+            client.send_message("Forbidden request")
+
+    assert not isinstance(exc_info.value, ServerError)
+    assert exc_info.value.status_code == 403
+
     requests = httpx_mock.get_requests()
     assert len(requests) == 1
 
@@ -264,6 +444,24 @@ def test_async_client_init_empty_url() -> None:
     """Ensure AsyncChatClient raises ConfigurationError if webhook is empty."""
     with pytest.raises(ConfigurationError):
         AsyncChatClient(webhook_url="")
+
+
+def test_async_client_init_negative_max_retries() -> None:
+    """Ensure AsyncChatClient raises ConfigurationError for negative max_retries."""
+    with pytest.raises(ConfigurationError, match="max_retries"):
+        AsyncChatClient(WEBHOOK_URL, max_retries=-1)
+
+
+def test_async_client_init_negative_retry_wait_min() -> None:
+    """Ensure AsyncChatClient raises ConfigurationError for negative retry_wait_min."""
+    with pytest.raises(ConfigurationError, match="retry_wait_min"):
+        AsyncChatClient(WEBHOOK_URL, retry_wait_min=-1.0)
+
+
+def test_async_client_init_retry_wait_max_less_than_min() -> None:
+    """Ensure AsyncChatClient raises ConfigurationError when max < min wait."""
+    with pytest.raises(ConfigurationError, match="retry_wait_max"):
+        AsyncChatClient(WEBHOOK_URL, retry_wait_min=10.0, retry_wait_max=5.0)
 
 
 @pytest.mark.asyncio
@@ -475,8 +673,69 @@ async def test_async_rate_limit_retry_after_header_missing(
 
 
 @pytest.mark.asyncio
+async def test_async_rate_limit_retry_after_negative_clamped(
+    httpx_mock: HTTPXMock,
+) -> None:
+    """Test that a negative delay-seconds value is clamped to 0 (async)."""
+    httpx_mock.add_response(
+        status_code=429,
+        text="Too Many Requests",
+        headers={"Retry-After": "-10"},
+    )
+
+    async with AsyncChatClient(
+        WEBHOOK_URL, max_retries=0, retry_wait_min=0, retry_wait_max=0
+    ) as client:
+        with pytest.raises(RateLimitError) as exc_info:
+            await client.send_message("Negative retry-after")
+
+    assert exc_info.value.retry_after == 0.0
+
+
+@pytest.mark.asyncio
+async def test_async_rate_limit_retry_after_http_date(httpx_mock: HTTPXMock) -> None:
+    """Test that HTTP-date Retry-After is parsed to a non-negative delay (async)."""
+    future = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(
+        seconds=30
+    )
+    http_date = future.strftime("%a, %d %b %Y %H:%M:%S GMT")
+    httpx_mock.add_response(
+        status_code=429,
+        text="Too Many Requests",
+        headers={"Retry-After": http_date},
+    )
+
+    async with AsyncChatClient(
+        WEBHOOK_URL, max_retries=0, retry_wait_min=0, retry_wait_max=0
+    ) as client:
+        with pytest.raises(RateLimitError) as exc_info:
+            await client.send_message("HTTP-date retry-after")
+
+    assert exc_info.value.retry_after is not None
+    assert exc_info.value.retry_after >= 0.0
+
+
+@pytest.mark.asyncio
+async def test_async_rate_limit_retry_after_unparseable(httpx_mock: HTTPXMock) -> None:
+    """Test that an unparseable Retry-After results in retry_after=None (async)."""
+    httpx_mock.add_response(
+        status_code=429,
+        text="Too Many Requests",
+        headers={"Retry-After": "not-a-valid-value"},
+    )
+
+    async with AsyncChatClient(
+        WEBHOOK_URL, max_retries=0, retry_wait_min=0, retry_wait_max=0
+    ) as client:
+        with pytest.raises(RateLimitError) as exc_info:
+            await client.send_message("Unparseable retry-after")
+
+    assert exc_info.value.retry_after is None
+
+
+@pytest.mark.asyncio
 async def test_async_non_429_error_not_retried(httpx_mock: HTTPXMock) -> None:
-    """Test that non-429 errors are NOT retried (async)."""
+    """Test that non-retryable errors (e.g. 400) are NOT retried (async)."""
     httpx_mock.add_response(status_code=400, text="Bad Request")
 
     async with AsyncChatClient(
@@ -487,6 +746,118 @@ async def test_async_non_429_error_not_retried(httpx_mock: HTTPXMock) -> None:
 
     assert not isinstance(exc_info.value, RateLimitError)
     assert exc_info.value.status_code == 400
+
+    requests = httpx_mock.get_requests()
+    assert len(requests) == 1
+
+
+# ---------------------------------------------------------------------------
+# Asynchronous Client Retry Tests (5xx Server Errors)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_async_server_error_raises_server_error(httpx_mock: HTTPXMock) -> None:
+    """Test that a 500 response raises ServerError, not generic APIError (async)."""
+    httpx_mock.add_response(status_code=500, text="Internal Server Error")
+
+    async with AsyncChatClient(
+        WEBHOOK_URL, max_retries=0, retry_wait_min=0, retry_wait_max=0
+    ) as client:
+        with pytest.raises(ServerError) as exc_info:
+            await client.send_message("This will fail with 500")
+
+    assert exc_info.value.status_code == 500
+    assert "500" in str(exc_info.value)
+    assert "Internal Server Error" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_async_server_error_is_api_error_subclass(httpx_mock: HTTPXMock) -> None:
+    """Test that ServerError is catchable as APIError (async)."""
+    httpx_mock.add_response(status_code=503, text="Service Unavailable")
+
+    async with AsyncChatClient(
+        WEBHOOK_URL, max_retries=0, retry_wait_min=0, retry_wait_max=0
+    ) as client:
+        with pytest.raises(APIError) as exc_info:
+            await client.send_message("This will fail with 503")
+
+    assert isinstance(exc_info.value, ServerError)
+    assert exc_info.value.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_async_server_error_retry_succeeds(httpx_mock: HTTPXMock) -> None:
+    """Test that a transient 500 followed by a 200 succeeds after retry (async)."""
+    httpx_mock.add_response(status_code=500, text="Internal Server Error")
+    httpx_mock.add_response(
+        status_code=200, json={"name": "spaces/SPACE/messages/MSG", "text": "OK"}
+    )
+
+    async with AsyncChatClient(
+        WEBHOOK_URL, max_retries=1, retry_wait_min=0, retry_wait_max=0
+    ) as client:
+        response = await client.send_message("Retry me")
+
+    assert response == {"name": "spaces/SPACE/messages/MSG", "text": "OK"}
+
+    requests = httpx_mock.get_requests()
+    assert len(requests) == 2
+
+
+@pytest.mark.asyncio
+async def test_async_server_error_multiple_retries_then_success(
+    httpx_mock: HTTPXMock,
+) -> None:
+    """Test that multiple 5xx responses are retried until success (async)."""
+    httpx_mock.add_response(status_code=502, text="Bad Gateway")
+    httpx_mock.add_response(status_code=503, text="Service Unavailable")
+    httpx_mock.add_response(status_code=200, json={"text": "Finally!"})
+
+    async with AsyncChatClient(
+        WEBHOOK_URL, max_retries=2, retry_wait_min=0, retry_wait_max=0
+    ) as client:
+        response = await client.send_message("Retry me twice")
+
+    assert response == {"text": "Finally!"}
+
+    requests = httpx_mock.get_requests()
+    assert len(requests) == 3
+
+
+@pytest.mark.asyncio
+async def test_async_server_error_retry_exhausted(httpx_mock: HTTPXMock) -> None:
+    """Test that ServerError is raised after all retries are exhausted (async)."""
+    httpx_mock.add_response(status_code=500, text="Internal Server Error")
+    httpx_mock.add_response(status_code=500, text="Internal Server Error")
+    httpx_mock.add_response(status_code=500, text="Internal Server Error")
+
+    async with AsyncChatClient(
+        WEBHOOK_URL, max_retries=2, retry_wait_min=0, retry_wait_max=0
+    ) as client:
+        with pytest.raises(ServerError) as exc_info:
+            await client.send_message("This will exhaust retries")
+
+    assert exc_info.value.status_code == 500
+
+    requests = httpx_mock.get_requests()
+    assert len(requests) == 3
+
+
+@pytest.mark.asyncio
+async def test_async_4xx_not_retried_but_5xx_is(httpx_mock: HTTPXMock) -> None:
+    """Test that 4xx errors (except 429) are not retried while 5xx would be (async)."""
+    httpx_mock.add_response(status_code=403, text="Forbidden")
+
+    async with AsyncChatClient(
+        WEBHOOK_URL, max_retries=2, retry_wait_min=0, retry_wait_max=0
+    ) as client:
+        with pytest.raises(APIError) as exc_info:
+            await client.send_message("Forbidden request")
+
+    assert not isinstance(exc_info.value, ServerError)
+    assert exc_info.value.status_code == 403
 
     requests = httpx_mock.get_requests()
     assert len(requests) == 1


### PR DESCRIPTION
## Summary
Adds automatic retry handling for HTTP 429 (Too Many Requests) responses in both `ChatClient` and `AsyncChatClient`, using exponential backoff with configurable parameters and optional `Retry-After` header support.
## Issues Closed
Closes #6 
## Changes
### New Exception: `RateLimitError`
- Added `RateLimitError` as a subclass of `APIError` in `src/chatapult/exceptions.py`
- Parses the `Retry-After` response header (when present) and exposes it as `retry_after: Optional[float]`
- Exported from the top-level `chatapult` package via `__init__.py` and `__all__`
### Retry Utility: `retry_upon_rate_limit`
- New module `src/chatapult/utils/rate_limit_utils.py` implementing a `tenacity`-based retry decorator
- Uses exponential backoff (`wait_exponential`) by default, but respects the  `Retry-After` header value from `RateLimitError` when available
- Configurable via `max_retries`, `retry_wait_min`, and `retry_wait_max` parameters
### Client Updates
- Both `ChatClient` and `AsyncChatClient` now accept `max_retries`, `retry_wait_min`, and `retry_wait_max` constructor parameters
  (defaults: `3`, `1.0s`, `60.0s`)
- `send_message()` in both clients now distinguishes 429 responses from other HTTP errors, raising `RateLimitError` instead of generic `APIError`
- The inner HTTP call is wrapped with `@retry_upon_rate_limit` so transient rate limits are retried transparently
### Dependencies
- Added `tenacity>=9.0.0` as a runtime dependency in `pyproject.toml`
### Tests
- Added 16 new test cases in `tests/test_clients.py` (8 sync + 8 async) covering:
  - 429 raises `RateLimitError` (and is a subclass of `APIError`)
  - Successful retry after transient 429
  - Multiple consecutive 429s followed by success
  - Retry exhaustion raises `RateLimitError`
  - `Retry-After` header parsing (present and absent)
  - Non-429 errors (e.g., 400) are **not** retried
## Rationale
Google Chat webhooks enforce rate limits that return HTTP 429 responses. Without automatic retries, callers must implement their own backoff logic. This change provides a robust, opt-in retry mechanism out of the box while keeping the default behavior safe and configurable.
## Checklist
- [x] Code follows the project's coding standards (type hints, docstrings)
- [x] `pre-commit run --all-files` passes (black, ruff, mypy)
- [x] Unit tests added for new functionality
- [x] Documentation updated (inline docstrings)