### PR TITLE
Update timeout parameter type in AsyncChatClient and ChatClient constructors to accept both float and int

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Chatapult is designed to make sending automated notifications, CI/CD alerts, and
 * **Rich V2 Cards:** Construct complex Google Chat Cards and Widgets using clean Python objects instead of nested JSON.
 * **Threaded Replies:** Easily group related alerts by replying to specific message threads.
 * **Fully Typed:** Built with standard Python type hints for excellent IDE autocomplete and static checking.
+* **Configurable timeouts:** Set how long each HTTP request may take before it is aborted (default 10 seconds).
 
 ## Installation
 
@@ -76,6 +77,21 @@ if __name__ == "__main__":
 ```
 
 ![Async Message](https://raw.githubusercontent.com/DLambros91/chatapult/refs/heads/main/images/example_async_message.png)
+
+### Request timeout
+
+Both `ChatClient` and `AsyncChatClient` accept an optional `timeout` argument (`float` or `int`, in seconds). It is passed to the underlying HTTP client so slow or stuck requests fail instead of waiting indefinitely. The default is `10.0`.
+
+```python
+from chatapult import ChatClient, AsyncChatClient
+
+# Abort the request if it takes longer than 30 seconds (same for sync and async)
+with ChatClient(webhook_url, timeout=30) as client:
+    client.send_message("Hello!")
+
+async with AsyncChatClient(webhook_url, timeout=30) as client:
+    await client.send_message("Hello!")
+```
 
 ### Advanced Usage: Sending Rich V2 Cards
 

--- a/README.md
+++ b/README.md
@@ -85,14 +85,18 @@ Both `ChatClient` and `AsyncChatClient` accept an optional `timeout` argument (`
 ```python
 import os
 from chatapult import ChatClient, AsyncChatClient
+import asyncio
+from chatapult import ChatClient, AsyncChatClient
 
-webhook_url = os.environ.get("GOOGLE_CHAT_WEBHOOK_URL")
 # Abort the request if it takes longer than 30 seconds (same for sync and async)
 with ChatClient(webhook_url, timeout=30) as client:
     client.send_message("Hello!")
 
-async with AsyncChatClient(webhook_url, timeout=30) as client:
-    await client.send_message("Hello!")
+async def main():
+    async with AsyncChatClient(webhook_url, timeout=30) as client:
+        await client.send_message("Hello!")
+
+asyncio.run(main())
 ```
 
 ### Advanced Usage: Sending Rich V2 Cards

--- a/README.md
+++ b/README.md
@@ -83,8 +83,10 @@ if __name__ == "__main__":
 Both `ChatClient` and `AsyncChatClient` accept an optional `timeout` argument (`float` or `int`, in seconds). It is passed to the underlying HTTP client so slow or stuck requests fail instead of waiting indefinitely. The default is `10.0`.
 
 ```python
+import os
 from chatapult import ChatClient, AsyncChatClient
 
+webhook_url = os.environ.get("GOOGLE_CHAT_WEBHOOK_URL")
 # Abort the request if it takes longer than 30 seconds (same for sync and async)
 with ChatClient(webhook_url, timeout=30) as client:
     client.send_message("Hello!")

--- a/src/chatapult/async_client.py
+++ b/src/chatapult/async_client.py
@@ -18,7 +18,7 @@ class AsyncChatClient:
 
         Args:
             webhook_url (str): The full Google Chat webhook URL.
-            timeout (Union[float, int]): Connection timeout in seconds.
+            timeout (Union[float, int]): Request timeout in seconds.
             Defaults to 10.0. Optional.
 
         Raises:

--- a/src/chatapult/async_client.py
+++ b/src/chatapult/async_client.py
@@ -19,7 +19,7 @@ class AsyncChatClient:
         Args:
             webhook_url (str): The full Google Chat webhook URL.
             timeout (Union[float, int]): Request timeout in seconds.
-            Defaults to 10.0. Optional.
+                Defaults to 10.0. Optional.
 
         Raises:
             ConfigurationError: If the webhook_url is empty.

--- a/src/chatapult/async_client.py
+++ b/src/chatapult/async_client.py
@@ -13,12 +13,12 @@ class AsyncChatClient:
     loop.
     """
 
-    def __init__(self, webhook_url: str, timeout: float = 10.0) -> None:
+    def __init__(self, webhook_url: str, timeout: [float, int] = 10.0) -> None:
         """Initialize the AsyncChatClient.
 
         Args:
             webhook_url (str): The full Google Chat webhook URL.
-            timeout (float): Connection timeout in seconds. Defaults to 10.0.
+            timeout ([float, int]): Connection timeout in seconds. Defaults to 10.0.
 
         Raises:
             ConfigurationError: If the webhook_url is empty.

--- a/src/chatapult/async_client.py
+++ b/src/chatapult/async_client.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, List
+from typing import Any, Dict, Optional, List, Union
 
 import httpx
 
@@ -13,12 +13,13 @@ class AsyncChatClient:
     loop.
     """
 
-    def __init__(self, webhook_url: str, timeout: [float, int] = 10.0) -> None:
+    def __init__(self, webhook_url: str, timeout: Union[float, int] = 10.0) -> None:
         """Initialize the AsyncChatClient.
 
         Args:
             webhook_url (str): The full Google Chat webhook URL.
-            timeout ([float, int]): Connection timeout in seconds. Defaults to 10.0.
+            timeout (Union[float, int]): Connection timeout in seconds.
+            Defaults to 10.0. Optional.
 
         Raises:
             ConfigurationError: If the webhook_url is empty.

--- a/src/chatapult/client.py
+++ b/src/chatapult/client.py
@@ -18,7 +18,7 @@ class ChatClient:
 
         Args:
             webhook_url (str): The full Google Chat webhook URL.
-            timeout (Union[float, int]): Connection timeout in seconds.
+            timeout (Union[float, int]): Request timeout in seconds.
             Defaults to 10.0. Optional.
 
         Raises:

--- a/src/chatapult/client.py
+++ b/src/chatapult/client.py
@@ -19,7 +19,7 @@ class ChatClient:
         Args:
             webhook_url (str): The full Google Chat webhook URL.
             timeout (Union[float, int]): Request timeout in seconds.
-            Defaults to 10.0. Optional.
+                Defaults to 10.0. Optional.
 
         Raises:
             ConfigurationError: If the webhook_url is empty or invalid.

--- a/src/chatapult/client.py
+++ b/src/chatapult/client.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, List
+from typing import Any, Dict, Optional, List, Union
 
 import httpx
 
@@ -13,12 +13,13 @@ class ChatClient:
     This client uses httpx's Client to send messages in a blocking manner.
     """
 
-    def __init__(self, webhook_url: str, timeout: [float, int] = 10.0) -> None:
+    def __init__(self, webhook_url: str, timeout: Union[float, int] = 10.0) -> None:
         """Initialize the ChatClient.
 
         Args:
             webhook_url (str): The full Google Chat webhook URL.
-            timeout ([float, int]): Connection timeout in seconds. Defaults to 10.0.
+            timeout (Union[float, int]): Connection timeout in seconds.
+            Defaults to 10.0. Optional.
 
         Raises:
             ConfigurationError: If the webhook_url is empty or invalid.

--- a/src/chatapult/client.py
+++ b/src/chatapult/client.py
@@ -13,12 +13,12 @@ class ChatClient:
     This client uses httpx's Client to send messages in a blocking manner.
     """
 
-    def __init__(self, webhook_url: str, timeout: float = 10.0) -> None:
+    def __init__(self, webhook_url: str, timeout: [float, int] = 10.0) -> None:
         """Initialize the ChatClient.
 
         Args:
             webhook_url (str): The full Google Chat webhook URL.
-            timeout (float): Connection timeout in seconds. Defaults to 10.0.
+            timeout ([float, int]): Connection timeout in seconds. Defaults to 10.0.
 
         Raises:
             ConfigurationError: If the webhook_url is empty or invalid.


### PR DESCRIPTION
Closes #11 

Edits an optional timeout parameter to now accept `int` as well (default 10.0 seconds, Union[float, int]) to ChatClient and AsyncChatClient. The value is passed through to the underlying httpx.Client / httpx.AsyncClient, so requests fail with a timeout instead of hanging indefinitely when users set a limit. Constructor docstrings document the new argument.